### PR TITLE
Fix large CPU consumption on the heartbeat thread for WLForJupyter

### DIFF
--- a/WolframLanguageForJupyter/Resources/KernelForWolframLanguageForJupyter.wl
+++ b/WolframLanguageForJupyter/Resources/KernelForWolframLanguageForJupyter.wl
@@ -253,6 +253,7 @@ heldLocalSubmit = Replace[Hold[LocalSubmit[
 	];
 	While[
 		True,
+		SocketWaitNext[{heartbeatSocket}];
 		heartbeatRecv = SocketReadMessage[heartbeatSocket];
 		If[
 			FailureQ[heartbeatRecv],


### PR DESCRIPTION
This intends to fix an unrelated problem brought up in #1 .

On Linux, the "heartbeat" WolframKernel thread (a Jupyter messaging spec requirement) seems to be able to balloon to a large CPU consumption. (This "heartbeat" thread is distinct from the WolframKernel instance where the actual input typed in a Jupyter notebook is evaluated.)

The problem seems to be that the thread was using the command `SocketReadMessage` as a one-stop "block and wait for a message, then return it." Unfortunately, the blocking and waiting part is where the large CPU consumption can come from.

Adding an intermediary like `SocketWaitNext` for the "block and wait" stage ― a command that does not appear to be able to cause a CPU usage explosion ― seems to solve the problem.