### PR TITLE
Make discovery of the project directory by the install script more robust

### DIFF
--- a/configure-jupyter.wls
+++ b/configure-jupyter.wls
@@ -14,7 +14,7 @@ nolink = "configure-jupyter.wls: Communication with provided Wolfram Engine bina
 
 (* START: Helper symbols  *)
 
-projectHome = DirectoryName[$InputFileName];
+projectHome = If[StringQ[$InputFileName] && $InputFileName != "", DirectoryName[$InputFileName], Directory[]];
 
 (* establishes link with Wolfram Engine at mathB and evaluates $Version *)
 getVersionFromKernel[mathB_String] :=


### PR DESCRIPTION
Depending on the invocation, InputFileName can be an empty string.

In such circumstances, just use `Directory[]`.

This resolves an issue brought up in #8, using a fix adapted from code provided by @sakra.