### PR TITLE
Add rewrites for named character names (to named characters)

### DIFF
--- a/WolframLanguageForJupyter/Resources/CompletionUtilities.wl
+++ b/WolframLanguageForJupyter/Resources/CompletionUtilities.wl
@@ -1,0 +1,84 @@
+(************************************************
+				CompletionUtilities.wl
+*************************************************
+Description:
+	Utilities for the aiding in the
+		(auto-)completion of Wolfram Language
+		code
+Symbols defined:
+	rewriteNamedCharacters
+*************************************************)
+
+(************************************
+	Get[] guard
+*************************************)
+
+If[
+	!TrueQ[WolframLanguageForJupyter`Private`$GotCompletionUtilities],
+	
+	WolframLanguageForJupyter`Private`$GotCompletionUtilities = True;
+
+(************************************
+	load required
+		WolframLanguageForJupyter
+		files
+*************************************)
+
+	Get[FileNameJoin[{DirectoryName[$InputFileName], "Initialization.wl"}]]; (* unicodeNamedCharactersReplacements,
+																					verticalEllipsis *)
+
+(************************************
+	private symbols
+*************************************)
+
+	(* begin the private context for WolframLanguageForJupyter *)
+	Begin["`Private`"];
+
+(************************************
+	utilities for rewriting
+		Wolfram Language code
+*************************************)
+
+	(* rewrite names (in a code string) into named characters *)
+	rewriteNamedCharacters[codeToAnalyze_?StringQ] :=
+		Module[
+			{codeUsingFullReplacements},
+			codeUsingFullReplacements =
+				StringReplace[
+					codeToAnalyze,
+					Normal @ unicodeNamedCharactersReplacements
+				];
+			If[
+				StringCount[
+					codeUsingFullReplacements,
+					verticalEllipsis | "\\["
+				] != 1,
+				Return[{codeUsingFullReplacements}];
+			];
+			Return[
+				Flatten[
+					StringCases[
+						codeUsingFullReplacements,
+						before___ ~~ name : ((verticalEllipsis | "\\[") ~~ rest__ ~~ EndOfString) :>
+							(
+								(StringJoin[before, #1] &) /@
+									Values[
+										KeySelect[
+											unicodeNamedCharactersReplacements,
+											StringMatchQ[#1, name ~~ ___] &
+										]
+									]
+							)
+					]
+				]
+			];
+		];
+
+	(* end the private context for WolframLanguageForJupyter *)
+	End[]; (* `Private` *)
+
+(************************************
+	Get[] guard
+*************************************)
+
+] (* WolframLanguageForJupyter`Private`$GotCompletionUtilities *)

--- a/WolframLanguageForJupyter/Resources/Initialization.wl
+++ b/WolframLanguageForJupyter/Resources/Initialization.wl
@@ -125,7 +125,8 @@ If[
 							]
 					] &
 				) /@
-					(
+					(* only use lists with at least three items *)
+					Select[
 						(* parse the rows into their items (where each item is separated by two tabs) *)
 						(StringSplit[#1, "\t\t"] &) /@
 							(
@@ -135,8 +136,9 @@ If[
 									"\n"
 								(* drop the first row *)
 								][[2 ;;]]
-							)
-					);
+							),
+						(Length[#1] >= 3) &
+					];
 
 			(* parse the data into an association of names and the named characters they correspond to *)
 			unicodeNamedCharactersReplacements =

--- a/WolframLanguageForJupyter/Resources/Initialization.wl
+++ b/WolframLanguageForJupyter/Resources/Initialization.wl
@@ -9,6 +9,7 @@ Symbols defined:
 	applyHook,
 	$canUseFrontEnd,
 	$outputSetToTraditionalForm,
+	$outputSetToTeXForm,
 	$trueFormatType,
 	connectionAssoc,
 	bannerWarning,
@@ -98,7 +99,16 @@ If[
 	$canUseFrontEnd := (UsingFrontEnd[$FrontEnd] =!= Null);
 
 	$outputSetToTraditionalForm := (Lookup[Options[$Output], FormatType] === TraditionalForm);
-	$trueFormatType := If[$outputSetToTraditionalForm, TraditionalForm, #&];
+	$outputSetToTeXForm := (Lookup[Options[$Output], FormatType] === TeXForm);
+	$trueFormatType :=
+		Which[
+			$outputSetToTraditionalForm,
+			TraditionalForm,
+			$outputSetToTeXForm,
+			TeXForm,
+			True,
+			Identity
+		];
 
 	(* obtain details on how to connect to Jupyter, from Jupyter's invocation of "KernelForWolframLanguageForJupyter.wl" *)
 	connectionAssoc = ToString /@ Association[Import[$CommandLine[[4]], "JSON"]];

--- a/WolframLanguageForJupyter/Resources/KernelForWolframLanguageForJupyter.wl
+++ b/WolframLanguageForJupyter/Resources/KernelForWolframLanguageForJupyter.wl
@@ -36,7 +36,7 @@ Get[FileNameJoin[{DirectoryName[$InputFileName], "Initialization.wl"}]]; (* init
 Get[FileNameJoin[{DirectoryName[$InputFileName], "SocketUtilities.wl"}]]; (* sendFrame *)
 Get[FileNameJoin[{DirectoryName[$InputFileName], "MessagingUtilities.wl"}]]; (* getFrameAssoc, createReplyFrame *)
 
-Get[FileNameJoin[{DirectoryName[$InputFileName], "RequestHandlers.wl"}]]; (* executeRequestHandler *)
+Get[FileNameJoin[{DirectoryName[$InputFileName], "RequestHandlers.wl"}]]; (* executeRequestHandler, completeRequestHandler *)
 
 (************************************
 	private symbols
@@ -96,6 +96,10 @@ loop[] :=
 					"execute_request",
 					(* executeRequestHandler will read and update loopState *)
 					executeRequestHandler[];,
+					(* use the tab-completion functionality to rewrite named character names *)
+					"complete_request",
+					(* completeRequestHandler will read and update loopState *)
+					completeRequestHandler[];,
 					(* if asking the kernel to shutdown, set doShutdown to True *)
 					"shutdown_request",
 					loopState["replyMsgType"] = "shutdown_reply";

--- a/WolframLanguageForJupyter/Resources/OutputHandlingUtilities.wl
+++ b/WolframLanguageForJupyter/Resources/OutputHandlingUtilities.wl
@@ -209,10 +209,7 @@ If[
 						be identical to the string result of an InputForm-wrapped expression itself *)
 					({"&#", ToString[#1], ";"} & /@ 
 						ToCharacterCode[
-							(* toStringUsingOutput[result] *)
-							Quiet[
-								ToString[If[!isTeXWrapped, $trueFormatType[result], result]]
-							],
+							(* toStringUsingOutput[result] *) ToString[If[!isTeXWrapped, $trueFormatType[result], result]],
 							"Unicode"
 						]),
 

--- a/extras/custom.js
+++ b/extras/custom.js
@@ -1,0 +1,50 @@
+/* (adapted) from https://stackoverflow.com/a/19961519 by Erik Aigner */
+HTMLTextAreaElement.prototype.insertAtCaret = function (text) {
+	text = text || '';
+	if(document.selection) {
+		// IE
+		this.focus();
+		var sel = document.selection.createRange();
+		sel.text = text;
+	}
+	else if(this.selectionStart || this.selectionStart === 0) {
+		// Others
+		var startPos = this.selectionStart;
+		var endPos = this.selectionEnd;
+		this.value = this.value.substring(0, startPos) + text + this.value.substring(endPos, this.value.length);
+		this.selectionStart = startPos + text.length;
+		this.selectionEnd = startPos + text.length;
+	}
+	else {
+		this.value += text;
+	}
+};
+
+/* (adapted) from https://stackoverflow.com/a/51114347 by bambam */
+function redirectEsc(event) {
+	if(event.which == 27)
+	{
+		event.target.insertAtCaret(
+				/* the vertical ellipsis character */
+				String.fromCharCode(8942)
+			);
+		event.preventDefault();
+	}
+}
+
+/* (adapted) from https://stackoverflow.com/a/51114347 by bambam */
+var observer = new MutationObserver(function(mutations) {
+
+	Array.from(
+			document.querySelectorAll('.input_area')
+		).forEach(
+				textarea =>
+				{
+					textarea.removeEventListener('keydown', redirectEsc);
+					textarea.addEventListener('keydown', redirectEsc);
+				}
+		);
+
+});
+
+observer.observe(document, {childList:true, subtree:true});

--- a/extras/custom.js
+++ b/extras/custom.js
@@ -28,7 +28,7 @@ function redirectEsc(event) {
 				/* the vertical ellipsis character */
 				String.fromCharCode(8942)
 			);
-		event.preventDefault();
+		event.stopImmediatePropagation();
 	}
 }
 


### PR DESCRIPTION
This implements a feature request brought up in #45.

This pull request allows one to type the vertical ellipsis character, and then all or part of a named character name or shortcut: tab-completion should then show possible named characters that could complete said name or shortcut.

NOTE:
To type the vertical ellipsis character, place the javascript file at `extras/custom.js` in a special location according to your platform (e.g., `~/.jupyter/custom/custom.js`). See also https://stackoverflow.com/a/39921293.

The code will then redirect all keypresses of the escape character (`Esc`) to the vertical ellipsis character, in all Jupyter notebooks, **irrespective of the kernel type.**