### PR TITLE
configure-jupyter.wls: fix typo in function name

### DIFF
--- a/configure-jupyter.wls
+++ b/configure-jupyter.wls
@@ -160,7 +160,7 @@ attemptPathRegeneration[] := If[
 
 (* find Jupyter installation path *)
 (* returns kernel IDs in Jupyter *)
-findJupyerPath[] := 
+findJupyterPath[] := 
 	SelectFirst[
 		splitPath,
 		(* check every directory in PATH to see if a Jupyter binary is a member *)
@@ -231,7 +231,7 @@ configureJupyter[specs_Association, removeQ_?BooleanQ, removeAllQ_?BooleanQ] :=
 		(* if no Jupyter installation path provided, determine it from PATH *)
 		If[
 			MissingQ[jupyterPath],
-			jupyterPath = findJupyerPath[];
+			jupyterPath = findJupyterPath[];
 			(* if Jupyter not on PATH, message *)
 			If[MissingQ[jupyterPath],
 				Print[notfound];


### PR DESCRIPTION
Fix function name `findJupyerPath` to be `findJupyterPath`.