### PR TITLE
WolframLanguageForJupyter.m: fix typo in function name

### DIFF
--- a/WolframLanguageForJupyter/WolframLanguageForJupyter.m
+++ b/WolframLanguageForJupyter/WolframLanguageForJupyter.m
@@ -139,7 +139,7 @@ splitPath :=
 
 (* find Jupyter installation path *)
 (* returns above *)
-findJupyerPath[] := 
+findJupyterPath[] := 
 	SelectFirst[
 		splitPath,
 		(* check every directory in PATH to see if a Jupyter binary is a member *)
@@ -211,7 +211,7 @@ configureJupyter[specs_Association, removeQ_?BooleanQ, removeAllQ_?BooleanQ] :=
 		(* if no Jupyter installation path provided, determine it from PATH *)
 		If[
 			MissingQ[jupyterPath],
-			jupyterPath = findJupyerPath[];
+			jupyterPath = findJupyterPath[];
 			(* if Jupyter not on PATH, message *)
 			If[MissingQ[jupyterPath],
 				Message[ConfigureJupyter::notfound, "Jupyter"];

--- a/configure-jupyter.wls
+++ b/configure-jupyter.wls
@@ -160,7 +160,7 @@ attemptPathRegeneration[] := If[
 
 (* find Jupyter installation path *)
 (* returns kernel IDs in Jupyter *)
-findJupyerPath[] := 
+findJupyterPath[] := 
 	SelectFirst[
 		splitPath,
 		(* check every directory in PATH to see if a Jupyter binary is a member *)
@@ -231,7 +231,7 @@ configureJupyter[specs_Association, removeQ_?BooleanQ, removeAllQ_?BooleanQ] :=
 		(* if no Jupyter installation path provided, determine it from PATH *)
 		If[
 			MissingQ[jupyterPath],
-			jupyterPath = findJupyerPath[];
+			jupyterPath = findJupyterPath[];
 			(* if Jupyter not on PATH, message *)
 			If[MissingQ[jupyterPath],
 				Print[notfound];


### PR DESCRIPTION
This complements #66 by fixing the same issue (the typo in `findJupyerPath`) in the other file where it is found, `WolframLanguageForJupyter/WolframLanguageForJupyter.m`.