### PR TITLE
Use the current PageWidth setting for $Output when converting a result into a string

### DIFF
--- a/WolframLanguageForJupyter/Resources/Initialization.wl
+++ b/WolframLanguageForJupyter/Resources/Initialization.wl
@@ -5,12 +5,14 @@ Description:
 	Initialization for
 		WolframLanguageForJupyter
 Symbols defined:
+	$defaultPageWidth,
 	loopState,
 	applyHook,
 	$canUseFrontEnd,
 	$outputSetToTraditionalForm,
 	$outputSetToTeXForm,
 	$trueFormatType,
+	$truePageWidth,
 	connectionAssoc,
 	bannerWarning,
 	keyString,
@@ -57,7 +59,8 @@ If[
 *************************************)
 
 	(* make Short[] work *)
-	SetOptions[$Output, PageWidth -> 89];
+	$defaultPageWidth = 89;
+	SetOptions[$Output, PageWidth -> $defaultPageWidth];
 
 (* 	do not output messages to the jupyter notebook invocation
 	$Messages = {};
@@ -223,6 +226,14 @@ If[
 			$outputSetToTraditionalForm,
 			TraditionalForm,
 			If[$outputSetToTeXForm, TeXForm, #&]
+		];
+	$truePageWidth :=
+		Replace[
+			Lookup[Options[$Output], PageWidth],
+			Except[
+				pageWidth_ /; ((IntegerQ[pageWidth]) && (pageWidth > 0))
+			] ->
+				$defaultPageWidth
 		];
 
 	(* hard-coded base64 rasterization of $Failed *)

--- a/WolframLanguageForJupyter/Resources/OutputHandlingUtilities.wl
+++ b/WolframLanguageForJupyter/Resources/OutputHandlingUtilities.wl
@@ -32,7 +32,8 @@ If[
 
 	Get[FileNameJoin[{DirectoryName[$InputFileName], "Initialization.wl"}]]; (* $canUseFrontEnd, $outputSetToTeXForm,
 																					$outputSetToTraditionalForm,
-																					$trueFormatType, failedInBase64 *)
+																					$trueFormatType, $truePageWidth,
+																					failedInBase64 *)
 
 (************************************
 	private symbols
@@ -182,7 +183,16 @@ If[
 	(* generate the textual form of a result *)
 	(* NOTE: the OutputForm (which ToString uses) of any expressions wrapped with, say, InputForm should
 		be identical to the string result of an InputForm-wrapped expression itself *)
-	toText[result_] := ToString[If[Head[result] =!= TeXForm, $trueFormatType[result], result]];
+	toText[result_] :=
+		ToString[
+			If[
+				Head[result] =!= TeXForm,
+				$trueFormatType[result],
+				result
+			],
+			(* also, use the current PageWidth setting for $Output *)
+			PageWidth -> $truePageWidth
+		];
 
 	(* generate HTML for the textual form of a result *)
 	toOutTextHTML[result_] := 


### PR DESCRIPTION
This intends to fix an issue brought up in #74.