### PR TITLE
Do not allow line breaks when generating TeX source for `text/html` results; allow setting PageWidth to Infinity

### DIFF
--- a/WolframLanguageForJupyter/Resources/Initialization.wl
+++ b/WolframLanguageForJupyter/Resources/Initialization.wl
@@ -234,7 +234,10 @@ If[
 		Replace[
 			Lookup[Options[$Output], PageWidth],
 			Except[
-				pageWidth_ /; ((IntegerQ[pageWidth]) && (pageWidth > 0))
+				Alternatives[
+					Infinity,
+					pageWidth_ /; ((IntegerQ[pageWidth]) && (pageWidth > 0))
+				]
 			] ->
 				$defaultPageWidth
 		];


### PR DESCRIPTION
This intends to fix an issue brought up in #83.