### PR TITLE
Add reverse color support

### DIFF
--- a/WolframLanguageForJupyter/Resources/OutputHandlingUtilities.wl
+++ b/WolframLanguageForJupyter/Resources/OutputHandlingUtilities.wl
@@ -384,7 +384,7 @@ If[
 					"alt=\"Output\" src=\"data:image/png;base64,",
 					imageInBase64,
 					(* end the element *)
-					"\">"
+					"\" style=\"filter: invert(100%)\">"
 				]
 			]
 		];


### PR DESCRIPTION
In Mathematica there is an option to make background look dark and texts bright, that is to use the "ReverseColor" stylesheet in the View menu. However WolframLanguageForJupyter does not support that, which annoys me as I am gotten used to see dark web pages and that's what I am doing.