### PR TITLE
Fix issue regarding message frame parsing

### DIFF
--- a/WolframLanguageForJupyter/Resources/MessagingUtilities.wl
+++ b/WolframLanguageForJupyter/Resources/MessagingUtilities.wl
@@ -63,11 +63,11 @@ If[
 					(* see https://jupyter-client.readthedocs.io/en/stable/messaging.html *)
 					StringCases[
 						frameStr,
-						ident1___ ~~ "<IDS|MSG>" ~~ ___ ~~ 
-							"{" ~~ json2___ ~~ "}" ~~
-								"{" ~~ json3___ ~~ "}" ~~
-									"{" ~~ json4___ ~~ "}" ~~
-										"{" ~~ json5___ ~~ "}" ~~
+						Shortest[ident1___] ~~ "<IDS|MSG>" ~~ Shortest[___] ~~ 
+							"{" ~~ Shortest[json2___] ~~ "}" ~~
+								"{" ~~ Shortest[json3___] ~~ "}" ~~
+									"{" ~~ Shortest[json4___] ~~ "}" ~~
+										"{" ~~ Shortest[json5___] ~~ "}" ~~
 											EndOfString :> 
 							Prepend[
 								(* add back in the brackets *)


### PR DESCRIPTION
This intends to fix an issue brought up in #83, specifically the [following comment by @glennhanks](https://github.com/WolframResearch/WolframLanguageForJupyter/issues/83#issuecomment-623323448):

> One more problem: `ToExpression[" \\frac{1}{2} ", TeXForm]` does not work. According to the source of ipynb, it shows:
> `"source": [ "ToExpression[\" \\\\frac{1}{2} \", TeXForm]" ]`