### PR TITLE
Add on-demand licensing support

### DIFF
--- a/WolframLanguageForJupyter/Resources/Initialization.wl
+++ b/WolframLanguageForJupyter/Resources/Initialization.wl
@@ -257,7 +257,7 @@ If[
 	(* warnings to display in kernel information *)
 	bannerWarning = 
 		If[
-			Length[$CommandLine] > 4,
+			MemberQ[$CommandLine, "ScriptInstall"],
 			"\\n\\nNote: This Jupyter kernel was installed through the WolframScript install method. Accordingly, updates to a WolframLanguageForJupyter paclet will not affect this kernel.",
 			""
 		];

--- a/configure-jupyter.wls
+++ b/configure-jupyter.wls
@@ -25,6 +25,7 @@ nolink = "configure-jupyter.wls: Communication with provided Wolfram Engine bina
 (* START: Helper symbols  *)
 
 projectHome = If[StringQ[$InputFileName] && $InputFileName != "", DirectoryName[$InputFileName], Directory[]];
+defaultOnDemandLicenseServer = "cloudlm.wolfram.com";
 
 (* establishes link with Wolfram Engine at mathBin and evaluates $Version/$VersionNumber *)
 (* returns string form *)
@@ -32,12 +33,13 @@ getVersionFromKernel[mathBin_String] :=
 	Module[{link, res},
 		link = 
 			LinkLaunch[
-				StringJoin[
-					{
-						"\"",
-						mathBin,
-						"\" -wstp"
-					}
+				StringRiffle[
+					Flatten@{
+						"\"" <> mathBin <> "\"",
+						"-wstp",
+						onDemandLicensingArguments[]
+					},
+					" "
 				]
 			];
 		If[FailureQ[link],
@@ -157,6 +159,30 @@ attemptPathRegeneration[] := If[
 					]
 		];
 	];
+
+(* returns a list of WolframKernel CLI args for on-demand licensing based on the
+	WOLFRAMSCRIPT_ENTITLEMENTID envar; empty list if the variable is absent *)
+onDemandLicensingArguments[] := onDemandLicensingArguments[Association@GetEnvironment[]]
+onDemandLicensingArguments[processEnvironment_Association] := Module[{
+	entitlementID = processEnvironment["WOLFRAMSCRIPT_ENTITLEMENTID"],
+	licenseServer = Lookup[
+		processEnvironment,
+		"WOLFRAMSCRIPT_CLOUDLICENSESERVER",
+		defaultOnDemandLicenseServer
+	]
+},
+	If[
+		(* if the envar is absent or too short *)
+		!StringQ[entitlementID] || StringLength[entitlementID] < 2,
+		(* then return an empty list *)
+		Return[{}]
+	];
+
+	Return@{
+		"-pwfile", "\"!" <> licenseServer <> "\"",
+		"-entitlement", "\"" <> entitlementID <> "\""
+	}
+]
 
 (* find Jupyter installation path *)
 (* returns kernel IDs in Jupyter *)
@@ -310,7 +336,13 @@ configureJupyter[specs_Association, removeQ_?BooleanQ, removeAllQ_?BooleanQ] :=
 			Export[
 				FileNameJoin[{tempDir, "kernel.json"}], 
 				Association[
-					"argv" -> {mathBin, "-script", kernelScript, "{connection_file}", "ScriptInstall" (* , "-noprompt" *)},
+					"argv" -> Flatten@{
+						mathBin,
+
+						"-script", kernelScript,
+						"{connection_file}", "ScriptInstall", (* "-noprompt", *)
+						StringTrim[onDemandLicensingArguments[processEnvironment], "\""]
+					},
 					"display_name" -> displayName,
 					"language" -> "Wolfram Language"
 				]


### PR DESCRIPTION
The on-demand licensing functionality introduced in 12.2 is supported by the kernel and WolframScript. It's usually activated by starting WolframScript with either the `-entitlement` argument or the `WOLFRAMSCRIPT_ENTITLEMENTID` environment variable. As the Wolfram Language Jupyter kernel interacts with the WolframKernel process directly, this environment variable is ignored. This PR detects the `WOLFRAMSCRIPT_ENTITLEMENTID` environment variable and passes it through to WolframKernel on the command line along with the appropriate `-pwfile` argument (which in WolframScript is added automatically).

I have tested these changes via `configure-jupyter.wls` in Linux. I have not tested on Windows or macOS, nor have I tested configuring Jupyter via the functions in the paclet instead of the script.