### PR TITLE
Add support for latex output in VSCode Jupyter notebook

### DIFF
--- a/WolframLanguageForJupyter/Resources/OutputHandlingUtilities.wl
+++ b/WolframLanguageForJupyter/Resources/OutputHandlingUtilities.wl
@@ -211,13 +211,9 @@ If[
 					!isTeX,
 					{},
 					StringJoin[
-						(* mark the text as TeX, if is TeX *)
+						(* wrap the result with latex symbol *)
 						"$$",
-
-						(* the textual form of the result *)
 						toText[result, Infinity],
-
-						(* mark the text as TeX, if is TeX *)
 						"$$"
 					]
 				]

--- a/WolframLanguageForJupyter/Resources/OutputHandlingUtilities.wl
+++ b/WolframLanguageForJupyter/Resources/OutputHandlingUtilities.wl
@@ -198,6 +198,32 @@ If[
 	(* generate the textual form of a result using the current PageWidth setting for $Output *)
 	toText[result_] := toText[result, $truePageWidth];
 
+	toTeX[result_] := 
+		Module[
+			{
+				(* if the result should be marked as TeX *)
+				isTeX
+			},
+			(* check if the result should be marked as TeX *)
+			isTeX = ((Head[result] === TeXForm) || ($outputSetToTeXForm));
+			Return[
+				If[
+					!isTeX,
+					{},
+					StringJoin[
+						(* mark the text as TeX, if is TeX *)
+						"$$",
+
+						(* the textual form of the result *)
+						toText[result, Infinity],
+
+						(* mark the text as TeX, if is TeX *)
+						"$$"
+					]
+				]
+			];
+		];
+
 	(* generate HTML for the textual form of a result *)
 	toOutTextHTML[result_] := 
 		Module[

--- a/WolframLanguageForJupyter/Resources/OutputHandlingUtilities.wl
+++ b/WolframLanguageForJupyter/Resources/OutputHandlingUtilities.wl
@@ -209,7 +209,8 @@ If[
 			Return[
 				If[
 					!isTeX,
-					{},
+					(* if not TeX, return $Failed *)
+					$Failed,
 					StringJoin[
 						(* wrap the result with latex symbol *)
 						"$$",

--- a/WolframLanguageForJupyter/Resources/RequestHandlers.wl
+++ b/WolframLanguageForJupyter/Resources/RequestHandlers.wl
@@ -366,8 +366,12 @@ If[
 											{outIndex, 1, Length[totalResult["EvaluationResult"]]}
 										]
 									],
-								"text/latex" ->
-									If[
+								Module[
+									(* list of the results in the TeX form *)
+									{
+										results
+									},
+									results = If[
 										loopState["isCompleteRequestSent"],
 										(* if an is_complete_request has been sent, assume jupyter-console is running the kernel,
 											and do not generate HTML *)
@@ -382,14 +386,21 @@ If[
 											(* Otherwise for single result, display the first one *)
 											If[
 												Length[totalResult["EvaluationResult"]] == 0,
-												"",
-												toTeX[First[totalResult["EvaluationResult"]]]
+												{$Failed},
+												{toTeX[First[totalResult["EvaluationResult"]]]}
 											]
 										]
+									];
+									(* check if any of the result is not in the TeXForm, if so, do not display TeX output *)
+									If[
+										MemberQ[results, $Failed],
+										Nothing,
+										"text/latex" -> results
 									]
+								]
 							},
 						(* no metadata *)
-						"metadata" -> {"text/html" -> {}, "text/plain" -> {}}
+						"metadata" -> {"text/html" -> {}, "text/plain" -> {}, "text/latex" -> {}}
 					],
 					"JSON",
 					"Compact" -> True

--- a/WolframLanguageForJupyter/Resources/RequestHandlers.wl
+++ b/WolframLanguageForJupyter/Resources/RequestHandlers.wl
@@ -293,6 +293,11 @@ If[
 						(* the data representing the results and messages *)
 						"data" ->
 							{
+								(* "text/plain" -> 
+									StringJoin[
+										toText[totalResult]
+									]
+								, *)
 								(* generate HTML for the results and messages *)
 								"text/html" ->
 									If[
@@ -360,7 +365,9 @@ If[
 											},
 											{outIndex, 1, Length[totalResult["EvaluationResult"]]}
 										]
-									]
+									],
+								"text/latex" ->
+									toTeX[First[totalResult["EvaluationResult"]]]
 							},
 						(* no metadata *)
 						"metadata" -> {"text/html" -> {}, "text/plain" -> {}}

--- a/WolframLanguageForJupyter/Resources/RequestHandlers.wl
+++ b/WolframLanguageForJupyter/Resources/RequestHandlers.wl
@@ -367,7 +367,6 @@ If[
 										]
 									],
 								"text/latex" ->
-									(* toTeX[First[totalResult["EvaluationResult"]]] *)
 									If[
 										loopState["isCompleteRequestSent"],
 										(* if an is_complete_request has been sent, assume jupyter-console is running the kernel,
@@ -375,11 +374,12 @@ If[
 										"",
 										If[
 											Length[totalResult["EvaluationResult"]] > 1,
+											(* If there are multiple results, display it line by line *)
 											Table[
-													toTeX[totalResult["EvaluationResult"][[outIndex]]]
-												,
+												toTeX[totalResult["EvaluationResult"][[outIndex]]],
 												{outIndex, 1, Length[totalResult["EvaluationResult"]]}
 											],
+											(* Otherwise for single result, display the first one *)
 											StringJoin[
 												If[
 													Length[totalResult["EvaluationResult"]] == 0,

--- a/WolframLanguageForJupyter/Resources/RequestHandlers.wl
+++ b/WolframLanguageForJupyter/Resources/RequestHandlers.wl
@@ -367,7 +367,28 @@ If[
 										]
 									],
 								"text/latex" ->
-									toTeX[First[totalResult["EvaluationResult"]]]
+									(* toTeX[First[totalResult["EvaluationResult"]]] *)
+									If[
+										loopState["isCompleteRequestSent"],
+										(* if an is_complete_request has been sent, assume jupyter-console is running the kernel,
+											and do not generate HTML *)
+										"",
+										If[
+											Length[totalResult["EvaluationResult"]] > 1,
+											Table[
+													toTeX[totalResult["EvaluationResult"][[outIndex]]]
+												,
+												{outIndex, 1, Length[totalResult["EvaluationResult"]]}
+											],
+											StringJoin[
+												If[
+													Length[totalResult["EvaluationResult"]] == 0,
+													"",
+													toTeX[First[totalResult["EvaluationResult"]]]
+												]
+											]
+										]
+									]
 							},
 						(* no metadata *)
 						"metadata" -> {"text/html" -> {}, "text/plain" -> {}}

--- a/WolframLanguageForJupyter/Resources/RequestHandlers.wl
+++ b/WolframLanguageForJupyter/Resources/RequestHandlers.wl
@@ -380,12 +380,10 @@ If[
 												{outIndex, 1, Length[totalResult["EvaluationResult"]]}
 											],
 											(* Otherwise for single result, display the first one *)
-											StringJoin[
-												If[
-													Length[totalResult["EvaluationResult"]] == 0,
-													"",
-													toTeX[First[totalResult["EvaluationResult"]]]
-												]
+											If[
+												Length[totalResult["EvaluationResult"]] == 0,
+												"",
+												toTeX[First[totalResult["EvaluationResult"]]]
 											]
 										]
 									]


### PR DESCRIPTION
## Background

While jupyterlab and jupyter notebook able to detect the latex output automatically, VSCode Jupyter could not do the same. VSCode Jupyter will only render latex equation if the output mimetype is `text/latex`, whereas the current version only supports `text/html` and `text/plain` as a fallback

I added changes such that it will enable `text/latex` mimetype output when the evaluation result allows. On my changes, I added `toTeX` method, which will wrap the result with `$$` to allow proper rendering from VSCode. 

## Comparison
![image](https://user-images.githubusercontent.com/55012032/186233012-5c1159b2-50e1-4bfc-ae91-264164315260.png)
![image](https://user-images.githubusercontent.com/55012032/186232162-0be9087f-1cbe-4b61-ad91-d100613ef5e5.png)
