### PR TITLE
MessagingUtilities.wl: reply timestamps are now in UTC and include timezone, fix #159

### DIFF
--- a/WolframLanguageForJupyter/Resources/MessagingUtilities.wl
+++ b/WolframLanguageForJupyter/Resources/MessagingUtilities.wl
@@ -133,7 +133,7 @@ If[
 							"header" -> ExportString[
 											Append[
 												header,
-												{"date" -> DateString["ISODateTime"], "msg_type" -> replyType, "msg_id" -> StringInsert[StringReplace[CreateUUID[], "-" -> ""], "-", 9]}
+												{"date" -> DateString[DateObject[Now, TimeZone -> 0], "ISODateTime"] <> "+00:00", "msg_type" -> replyType, "msg_id" -> StringInsert[StringReplace[CreateUUID[], "-" -> ""], "-", 9]}
 											],
 											"JSON",
 											"Compact" -> True


### PR DESCRIPTION
fix #159 